### PR TITLE
Cancel Apple Pay

### DIFF
--- a/ios/ApplePay.swift
+++ b/ios/ApplePay.swift
@@ -53,6 +53,9 @@ class ApplePay: UIViewController {
 extension ApplePay: PKPaymentAuthorizationViewControllerDelegate {
     func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         controller.dismiss(animated: true, completion: nil)
+        if (self.resolve != nil) {
+          self.resolve!("PAYMENT_CANCELLED")
+        }
     }
 
     func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didAuthorizePayment payment: PKPayment, completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {

--- a/ios/ApplePay.swift
+++ b/ios/ApplePay.swift
@@ -63,6 +63,7 @@ extension ApplePay: PKPaymentAuthorizationViewControllerDelegate {
         if token != nil {
             self.resolve!(token)
             completion(.success)
+            self.resolve = nil
         } else {
             self.resolve!("COULD_NOT_FIND_TOKEN")
             completion(.failure)

--- a/ios/ApplePay.swift
+++ b/ios/ApplePay.swift
@@ -39,7 +39,7 @@ class ApplePay: UIViewController {
             }
         }
     }
-    
+
     @objc(canMakePayments:withRejecter:)
     func canMakePayments(resolve: RCTPromiseResolveBlock,reject:RCTPromiseRejectBlock) -> Void {
         if PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: paymentNetworks!) {
@@ -67,6 +67,7 @@ extension ApplePay: PKPaymentAuthorizationViewControllerDelegate {
         } else {
             self.resolve!("COULD_NOT_FIND_TOKEN")
             completion(.failure)
+            self.resolve = nil
         }
     }
 }


### PR DESCRIPTION
This now allows you to know when a request to pay with apple pay is cancelled.

How this is achieved is by setting up `paymentAuthorizationViewControllerDidFinish` on the ApplePay class, this is called when the user either completes payment or cancels the apple pay sheet. Within this method we call self.resolve("PAYMENT_CANCELLED")

See here for more detail on this method (https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate).
> There is one exception to this step-by-step procedure: The pay authorization view controller calls the [paymentAuthorizationViewControllerDidFinish(_:)](https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontrollerdelegate/1616180-paymentauthorizationviewcontroll) method as soon as the user cancels a payment without authorizing a payment request, or when a payment is canceled after timing out. The controller can call this method at any time.

There's a catch to it though and that is, the promise resolve will be called twice if the user completes payment because we are also calling self.resolve in the `paymentAuthorizationViewController` method, the solution is to unset the resolve property on the ApplePay class after `paymentAuthorizationViewController` is called.

This works because if the user cancels payment, only `paymentAuthorizationViewControllerDidFinish` is called but if the user makes payment `paymentAuthorizationViewController` is first called and then `paymentAuthorizationViewControllerDidFinish` get's called.

## Example
### User Cancels Payment
System Calls -> paymentAuthorizationViewControllerDidFinish

### User Attempts Making Payment
System Calls ->  paymentAuthorizationViewController
Then System Call -> paymentAuthorizationViewControllerDidFinish

## Usage
With this the user can now perform the following to know if the Apple Pay Payment was cancelled.

```ts
const result = await paymentHandler.initApplePay();
if (result === "CANCELLED_PAYMENT") {
  return handleApplePayCancel()
}
if (result === "COULD_NOT_FIND_TOKEN") {
  return handleApplePayTokenError()
}
return doSomethingWithTheToken(result)
```
